### PR TITLE
Fix: Responsiveness issue in the Resources page (#240)

### DIFF
--- a/src/components/Blog/Blog.css
+++ b/src/components/Blog/Blog.css
@@ -127,7 +127,7 @@
   overflow: hidden;
 }
 
-.btnlatestoldest button.active {
+.btnlatestoldest button.active-button {
   color: rgba(80, 80, 80, 1);
 }
 

--- a/src/components/Blog/Blog.jsx
+++ b/src/components/Blog/Blog.jsx
@@ -114,21 +114,21 @@ const Blog = () => {
             <div className="btnlatestoldest">
               <button
                 onClick={() => handleSortingOrderChange("latest")}
-                className={sortingOrder === "latest" ? "active" : ""}
+                className={sortingOrder === "latest" ? "active-button" : ""}
               >
                 Latest
               </button>
               <button
                 onClick={() => handleSortingOrderChange("oldest")}
                 id="moreold"
-                className={sortingOrder === "oldest" ? "active" : ""}
+                className={sortingOrder === "oldest" ? "active-button" : ""}
               >
                 Oldest
               </button>
               <button
                 onClick={() => handleSortingOrderChange("likes")}
                 id="moreold"
-                className={sortingOrder === "likes" ? "active" : ""}
+                className={sortingOrder === "likes" ? "active-button" : ""}
               >
                 Most Liked
               </button>


### PR DESCRIPTION
This pull request addresses an issue (#240) where buttons assigned the 'active' class were incorrectly inheriting a 'width: 100vw;' property due to a [conflicting rule in the Sidebar.scss file](https://github.com/Ecell-NITS/e-cell-website-22/blob/a394435539f25580fdc9b881550d91b576c39290/src/components/Admin/Sidebar/Sidebar.scss#L118C5-L118C18). This caused overflow issues whenever the buttons were activated on a smaller screen.

Updated the jsx and css to utilize a more specific class selector for the active buttons (active-button) to prevent any more conflicts with the 'active' class.